### PR TITLE
modify the ubuntu 20.04 prereq to ensure that the header files are pr…

### DIFF
--- a/gluex_prereqs_ubuntu_20.04.sh
+++ b/gluex_prereqs_ubuntu_20.04.sh
@@ -19,7 +19,8 @@ cd /usr/include # for cernlib
 for file in ft2build.h config freetype.h fttypes.h ftsystem.h ftimage.h \
     fterrors.h ftmoderr.h fterrdef.h
 do
-    ln -s freetype2/$file .
+    fileloc=$(find /usr/include/freetype2/ -name $file )
+    ln -s fileloc .
 done
 
 cd /usr/include/freetype2 ; ln -s ../freetype2 freetype # for ROOT


### PR DESCRIPTION
…opperly found and linked.

not all the necessary header files are in usr/include/freetype2/ most of them are in a subdirectory 
this mod will search for the files to ensure the correct link is set.